### PR TITLE
bugfix: Debug Consent parameters is not being captured.

### DIFF
--- a/AdmobPlugin/gap_converter.mm
+++ b/AdmobPlugin/gap_converter.mm
@@ -146,13 +146,18 @@
 + (UMPRequestParameters *) godotDictionaryToUMPRequestParameters:(Dictionary) godotDictionary {
 	UMPRequestParameters *parameters = [[UMPRequestParameters alloc] init];
 
-	bool tagForUnderAgeOfConsent = godotDictionary["tag_for_under_age_of_consent"];
-	parameters.tagForUnderAgeOfConsent = tagForUnderAgeOfConsent;
+	if (godotDictionary.has("tag_for_under_age_of_consent")) {
+		bool tagForUnderAgeOfConsent = (bool) godotDictionary["tag_for_under_age_of_consent"];
+		parameters.tagForUnderAgeOfConsent = tagForUnderAgeOfConsent;
+	}
 
-	Dictionary consentDebugSettingsDictionary = godotDictionary["consent_debug_settings"];
+	bool debugMode = false;
+	if (godotDictionary.has("is_real")) {
+		debugMode = !(bool) godotDictionary["is_real"];
+	}
 
-	if (!consentDebugSettingsDictionary.is_empty()) {
-		parameters.debugSettings = [GAPConverter godotDictionaryToUMPDebugSettings:consentDebugSettingsDictionary];
+	if (debugMode) {
+		parameters.debugSettings = [GAPConverter godotDictionaryToUMPDebugSettings:godotDictionary];
 	}
 	
 	return parameters;


### PR DESCRIPTION
Hello @cengiz-pz, it's me again 😄 

I never got the chance to thank you for the work you did for setting up both android and ios versions of the plugin to be installed simultaneously, so thanks for that! Also thank you for the config file approach you setup for APP_ID, it is working fantastically. I finally got around to getting my iOS build for my game going, and I stumbled across and issue while testing that I am trying to address here.

It looks like you are searching for this consent_debug_settings sub dictionary, but if you take a look at the latest [ConsentRequestParameters](https://github.com/cengiz-pz/godot-admob-addon/blob/main/model/ConsentRequestParameters.gd), you will see this sub dictionary/key does not exist.

I opted for an approach very similar to the checks you have in your [android admob plugin](https://github.com/cengiz-pz/godot-android-admob-plugin/blob/aab4b5321f05c677622cba422ac17af3aece63d9/admob/src/main/java/org/godotengine/plugin/android/admob/AdmobPlugin.java#L917).

I was able to build this locally following your steps in the README, but I got stuck at that. I wasn't really sure what the next steps are after completing the build, how am I supposed to use this generated library with my Godot game? I don't see similar files in my editor where I installed the iOS Admob plugin via the asset library.