### PR TITLE
Updated SConstruct file to fix builds for Godot 4.4 Stable.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -25,7 +25,7 @@ opts.Add(BoolVariable('simulator', "Compilation platform", 'no'))
 opts.Add(BoolVariable('use_llvm', "Use the LLVM / Clang compiler", 'no'))
 opts.Add('target_name', 'Resulting file name.', '')
 opts.Add(PathVariable('target_path', 'The path where the lib is installed.', 'bin/lib/'))
-opts.Add(EnumVariable('version', 'Godot version to target', '', ['', '4.1', '4.2', '4.3']))
+opts.Add(EnumVariable('version', 'Godot version to target', '', ['', '4.1', '4.2', '4.3', '4.4']))
 
 # Updates the environment with the option variables.
 opts.Update(env)
@@ -103,7 +103,7 @@ env.Prepend(CXXFLAGS=['-DIOS_ENABLED'])
 env.Prepend(CXXFLAGS=['-DVERSION_4_0'])
 
 
-if env['version'] == '4.1' or env['version'] == '4.2' or env['version'] == '4.3':
+if env['version'] == '4.1' or env['version'] == '4.2' or env['version'] == '4.3' or env['version'] == '4.4':
 	env.Prepend(CFLAGS=['-std=gnu11'])
 	env.Prepend(CXXFLAGS=['-std=gnu++17'])
 


### PR DESCRIPTION
I successfully compiled with `./script/build.sh -A 4.4` command. Source code compiled without modifications. 

<img width="2056" alt="image" src="https://github.com/user-attachments/assets/1c830159-82c3-4ddb-a317-fc02eead1d2c" />

This is the final PR to check on the five iOS plugins you have. The https://github.com/cengiz-pz/godot-ios-inapp-review-plugin which uses xcodebuild has successfully compiled with version 4.4 without any modifications.

Thank you for supporting the Godot mobile community.